### PR TITLE
ConsoleWindowController testability enhancement.

### DIFF
--- a/src/main/java/com/goxr3plus/xr3player/controllers/windows/ConsoleWindowController.java
+++ b/src/main/java/com/goxr3plus/xr3player/controllers/windows/ConsoleWindowController.java
@@ -65,7 +65,7 @@ public class ConsoleWindowController extends StackPane {
 	private final Logger logger = Logger.getLogger(getClass().getName());
 
 	/** The Window */
-	private final Stage window = new Stage();
+	private Stage window;
 
 	/**
 	 * The Speech Recognition of the Application
@@ -84,6 +84,13 @@ public class ConsoleWindowController extends StackPane {
 	 * Constructor
 	 */
 	public ConsoleWindowController() {
+
+
+	}
+
+	private Stage initFromConstructor() {
+		Stage window;
+		window = new Stage();
 
 		// ------------------------------------FXMLLOADER
 		final FXMLLoader loader = new FXMLLoader(
@@ -108,6 +115,7 @@ public class ConsoleWindowController extends StackPane {
 			if (k.getCode() == KeyCode.ESCAPE)
 				window.close();
 		});
+		return window;
 	}
 
 	/**
@@ -115,6 +123,7 @@ public class ConsoleWindowController extends StackPane {
 	 */
 	@FXML
 	private void initialize() {
+		window = initFromConstructor();
 
 		// -- cssTextArea
 		cssTextArea.setEditable(false);

--- a/src/test/java/com/goxr3plus/xr3player/controllers/windows/ConsoleWindowControllerTest.java
+++ b/src/test/java/com/goxr3plus/xr3player/controllers/windows/ConsoleWindowControllerTest.java
@@ -1,0 +1,26 @@
+package com.goxr3plus.xr3player.controllers.windows;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConsoleWindowControllerTest {
+
+    @Test
+    void createInstance() {
+        new ConsoleWindowController();
+    }
+
+
+    @Test
+    void checkRegexps() {
+        // TODO: change into a parameterized test. (requires support in pom.xml)
+        final ConsoleWindowController instance = new ConsoleWindowController();
+
+        assertTrue(instance.pattern1.matcher("player:|22:aWord").matches());
+        // TODO: Was this really expected to pass? Or are only + and - allowed before the number?
+
+    }
+
+
+}


### PR DESCRIPTION
Make ConsoleWindowController possible (easier) to instantiate in a unit test.
Demonstration of a simple test that benefits from this change.

The change in ConsoleWindowController is one of several ways to make it easier to create an instance, without unnecessary external requirements. Perhaps not the best way. The main problem is with the Stage class, which is not easy to create an instance of. Therefore it's no longer done when ConsoleWindowController is created.

Merge this if you want, but I mean it mainly as something to think about.

Take a look at the second unit test. It passes, but I don't think it should.