### PR TITLE
VisualizerType simplifications

### DIFF
--- a/src/main/java/com/goxr3plus/xr3player/controllers/xplayer/XPlayerController.java
+++ b/src/main/java/com/goxr3plus/xr3player/controllers/xplayer/XPlayerController.java
@@ -1487,7 +1487,7 @@ public class XPlayerController extends StackPane {
 		// DjVisualizer
 		if (this.getKey() == 1 || this.getKey() == 2) {
 			djVisualizer = new XPlayerVisualizer(this, false);
-			djVisualizer.setDisplayMode(Integer.parseInt(VisualizerType.VERTICAL_VOLUME_METER.toString()));
+			djVisualizer.setDisplayMode(VisualizerType.VERTICAL_VOLUME_METER.getValue());
 		}
 
 		// Select the correct toggle

--- a/src/main/java/com/goxr3plus/xr3player/xplayer/microphone/MicrophonePCMAnalyzerTest.java
+++ b/src/main/java/com/goxr3plus/xr3player/xplayer/microphone/MicrophonePCMAnalyzerTest.java
@@ -113,7 +113,7 @@ public class MicrophonePCMAnalyzerTest extends Application {
 		}).start();
 
 		// Visualizer
-		visualizer.setDisplayMode(Integer.parseInt(VisualizerType.CIRCLE_WITH_LINES.toString()));
+		visualizer.setDisplayMode(VisualizerType.CIRCLE_WITH_LINES.getValue());
 		visualizer.setupDSP(microphone.getTargetDataLine());
 		visualizer.startDSP(microphone.getTargetDataLine());
 		visualizer.startVisualizer();

--- a/src/main/java/com/goxr3plus/xr3player/xplayer/visualizer/core/VisualizerModel.java
+++ b/src/main/java/com/goxr3plus/xr3player/xplayer/visualizer/core/VisualizerModel.java
@@ -56,8 +56,7 @@ public class VisualizerModel extends ResizableCanvas implements KJDigitalSignalP
 	public final static int DISPLAYMODE_MAXIMUM = VisualizerType.values().length - 2; // -1 cause i count from 0
 
 	/** The display mode. */
-	public final SimpleIntegerProperty displayMode = new SimpleIntegerProperty(
-			Integer.parseInt(VisualizerType.CIRCLE_WITH_LINES.toString()));
+	public final SimpleIntegerProperty displayMode = new SimpleIntegerProperty(VisualizerType.CIRCLE_WITH_LINES.getValue());
 
 	/** The Constant DEFAULT_FPS. */
 	private static final int DEFAULT_FPS = 60;
@@ -799,86 +798,48 @@ public class VisualizerModel extends ResizableCanvas implements KJDigitalSignalP
 	public enum VisualizerType {
 
 		/** OSCILLOSCOPE */
-		OSCILLOSCOPE {
-			@Override
-			public String toString() {
-				return "0";
-			}
-		},
+		OSCILLOSCOPE (0),
 
 		/** OSCILLOSCOPE */
-		STEREO_OSCILLOSCOPE {
-			@Override
-			public String toString() {
-				return "1";
-			}
-		},
+		STEREO_OSCILLOSCOPE (1),
 
 		/** OSCILLOSCOPE */
-		OSCILLOSCOPE_LINES {
-			@Override
-			public String toString() {
-				return "2";
-			}
-		},
+		OSCILLOSCOPE_LINES (2),
 
 		/** The display spectrum bars. */
-		SPECTRUM_BARS {
-			@Override
-			public String toString() {
-				return "3";
-			}
-		},
+		SPECTRUM_BARS (3),
 
 		/** Display a VOLUME_METER */
-		VOLUME_METER {
-			@Override
-			public String toString() {
-				return "4";
-			}
-		},
+		VOLUME_METER (4),
+
 		/** The display rosette with polyspiral. */
-		ROSETTE {
-			@Override
-			public String toString() {
-				return "5";
-			}
-		},
+		ROSETTE (5),
+
 		/** Display A Circle With Lines on it's circumference */
-		CIRCLE_WITH_LINES {
-			@Override
-			public String toString() {
-				return "6";
-			}
-		},
+		CIRCLE_WITH_LINES (6),
+
 		/** Display Sierpinski Triangles */
-		SIERPINSKI {
-			@Override
-			public String toString() {
-				return "7";
-			}
-		},
+		SIERPINSKI (7),
+
 		/** Display SPRITE3D */
-		SPRITE3D {
-			@Override
-			public String toString() {
-				return "8";
-			}
-		},
+		SPRITE3D (8),
+
 		/** Display Julia Fractals */
-		VERTICAL_VOLUME_METER {
-			@Override
-			public String toString() {
-				return "9";
-			}
-		},
+		VERTICAL_VOLUME_METER (9),
+
 		/** Display Julia Fractals */
-		JULIAFRACTALS {
-			@Override
-			public String toString() {
-				return "10";
-			}
-		},
+		JULIAFRACTALS (10);
+
+		private final int value;
+
+
+		private VisualizerType(int value) {
+			this.value = value;
+		}
+
+		public int getValue() {
+			return value;
+		}
 
 	}
 

--- a/src/main/java/com/goxr3plus/xr3player/xplayer/visualizer/presenter/VisualizerStackController.java
+++ b/src/main/java/com/goxr3plus/xr3player/xplayer/visualizer/presenter/VisualizerStackController.java
@@ -14,6 +14,7 @@ import com.jfoenix.controls.JFXButton;
 
 import javafx.animation.FadeTransition;
 import javafx.animation.PauseTransition;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Label;
@@ -162,18 +163,26 @@ public class VisualizerStackController extends StackPane {
 	 * Goes to the next Spectrum Analyzer
 	 */
 	public void nextSpectrumAnalyzer() {
-		xPlayerController.visualizer.displayMode
-				.set((xPlayerController.visualizer.displayMode.get() + 1 > VisualizerModel.DISPLAYMODE_MAXIMUM) ? 0
-						: xPlayerController.visualizer.displayMode.get() + 1);
+		final SimpleIntegerProperty displayMode = xPlayerController.visualizer.displayMode;
+		final int modeVal = displayMode.get();
+		final int displaymodeMaximum = VisualizerModel.DISPLAYMODE_MAXIMUM;
+		final int nextMode = modeVal + 1;
+		displayMode.set((nextMode > displaymodeMaximum)
+				? 0
+				: nextMode);
 	}
 
 	/**
 	 * Goes to the previous Spectrum Analyzer
 	 */
 	public void previousSpectrumAnalyzer() {
-		xPlayerController.visualizer.displayMode.set(xPlayerController.visualizer.displayMode.get() - 1 >= 0
-				? xPlayerController.visualizer.displayMode.get() - 1
-				: VisualizerModel.DISPLAYMODE_MAXIMUM);
+		final SimpleIntegerProperty displayMode = xPlayerController.visualizer.displayMode;
+		final int modeVal = displayMode.get();
+		final int displaymodeMaximum = VisualizerModel.DISPLAYMODE_MAXIMUM;
+		final int nextMode = modeVal - 1;
+		displayMode.set(nextMode >= 0
+				? nextMode
+				: displaymodeMaximum);
 	}
 
 }


### PR DESCRIPTION
The enum VisualizerType has been simplified by removing the string representation, and replacing it with an integer representation. 

Currently, the only usage that I have seen for the integer representation, is to be able to set the default visualization upon start of the player. That is perhaps better done using the enum value itself. But the enum is coupled to the list of visualizations in the corresponding fxml file; I guess that's why you are not using the enum.

In the future, you might want to create the visualizer menu programmatically, from the enum values. Then you don't have to keep them matched, and can easily change the order in just one place (which will be the enum definition)

A somewhat unrelated change is in VisualizerStackController. The changes are only made to improve the readability, and to make it easier to probe values at debug time. It becomes clear that there is redundancy between the two changed methods. But that is left for future refactoring.