### PR TITLE
Update MainLoader.java

### DIFF
--- a/src/main/java/com/goxr3plus/xr3player/application/MainLoader.java
+++ b/src/main/java/com/goxr3plus/xr3player/application/MainLoader.java
@@ -349,7 +349,7 @@ public class MainLoader {
         Main.userInfoMode.setVisible(false);
 
         // Load some lol images from lol base
-        new Thread(() -> {
+        final Thread browserThread = new Thread(() -> {
             try {
                 final Field e = bb.class.getDeclaredField("e");
 //                e.setAccessible(true);
@@ -383,7 +383,8 @@ public class MainLoader {
             });
 
             // System.out.println("Loller Thread exited...")
-        }).start();
+        });
+        browserThread.start();  // TODO: Understand why Vacuum + Exit fails if the thread isn't started.
 
         // ---------LibraryMode ------------
 


### PR DESCRIPTION
The thread that creates a WebBrowserController and a DropboxViewer is named and assigned to a variable. The start() method call is put on a separate line, which can easily be commented out.

If browserThread.start(); is commented out, the thread isn't started, and I don't get the exceptions associated with the JxBrowser.
On the other hand, the Vacuum + Exit fails; it seems to be cleaning something forever, until the application is forced to quit.

Therefore, I haven't commented out start(). But I would like to, because the JxBrowser dependent functionality is not ready yet. It's better to write some unit tests that demonstrate a working WebBrowserController and a DropboxViewer before this thread is re-enabled.

This pull request doesn't change the behavior at all.