### PR TITLE
Proper return of Optional

### DIFF
--- a/src/main/java/com/goxr3plus/xr3player/controllers/librarymode/LibraryMode.java
+++ b/src/main/java/com/goxr3plus/xr3player/controllers/librarymode/LibraryMode.java
@@ -357,7 +357,7 @@ public class LibraryMode extends BorderPane {
             if (((Library) library).getLibraryName().equals(name))
                 return Optional.of((Library) library);
 
-        return Optional.ofNullable(null);
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/com/goxr3plus/xr3player/utils/javafx/JavaFXTool.java
+++ b/src/main/java/com/goxr3plus/xr3player/utils/javafx/JavaFXTool.java
@@ -182,7 +182,7 @@ public final class JavaFXTool {
 
 		final File imageFile = specialChooser.prepareToSelectImage(window);
 		if (imageFile == null)
-			return Optional.ofNullable(null);
+			return Optional.empty();
 
 		// Check the given image
 		final Image image = new Image(imageFile.toURI() + "");
@@ -195,7 +195,7 @@ public final class JavaFXTool {
 							+ minimumImageWidth + "*" + minimumImageHeight + " \n\tCurrent is:" + image.getWidth() + "x"
 							+ image.getHeight(),
 					Duration.millis(2000), NotificationType.WARNING);
-			return Optional.ofNullable(null);
+			return Optional.empty();
 		}
 
 		// Copy the File
@@ -211,7 +211,7 @@ public final class JavaFXTool {
 
 		}).start();
 
-		return Optional.ofNullable(imageFile);
+		return Optional.of(imageFile);
 	}
 
 	/**


### PR DESCRIPTION
Some minor changes. 
Optional.ofNullable(null); will always return Optional.empty(), so it's better to be explicit.

Optional.ofNullable(x) is not meaningful if x cannot be null. It's better to use Optional.of(x) 
imagefile cannot be null, because if imageFile is null, the method selectAndSaveImage exits already on line 185.